### PR TITLE
Highlight spelling tip in streaming search results

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -157,7 +157,7 @@
 
         function displayStreamingResults(tracks) {
             if (tracks.length === 0) {
-                streamingSearchResultsDiv.innerHTML = '<p>No tracks with audio previews found for that combination. Try refining your search terms or check spelling.</p>';
+                streamingSearchResultsDiv.innerHTML = '<p>No tracks with audio previews found for that combination. Try refining your search terms or <strong>check your spelling</strong>.</p>';
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Emphasize correct spelling in the no-results message for streaming search.

## Testing
- `python -m py_compile app.py check.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae41e143408331bbbc5a24d25260d5