### PR TITLE
fix: update Deezer search endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -205,8 +205,8 @@ def search_streaming():
         return jsonify({"error": "Song title and artist name are required for streaming search"}), 400
 
     query = f'artist:"{artist_name}" track:"{song_title}"'
-    deezer_api_url = "https://api.deezer.com/search/track" 
-    params = {'q': query, 'limit': 10, 'output': 'json'} 
+    deezer_api_url = "https://api.deezer.com/search"
+    params = {'q': query, 'limit': 10}
 
     print(f"DEBUG: Searching Deezer with query: '{query}' at URL: {deezer_api_url}")
 


### PR DESCRIPTION
## Summary
- use Deezer `/search` endpoint instead of `/search/track`
- drop `output=json` parameter in search

## Testing
- `pytest -q`
- `curl -i "https://api.deezer.com/search?q=artist:%22Daft%20Punk%22%20track:%22Harder%2C%20Better%2C%20Faster%2C%20Stronger%22&limit=1" | head -n 20` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68af4cd6109c8331ac39bf26e7359c20