### PR TITLE
Use Gemini 1.5 Pro model

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,8 @@ try:
         gemini_llm = None
     else:
         genai.configure(api_key=gemini_api_key)
-        gemini_model_name = 'models/gemini-2.0-flash' # Your chosen Gemini model
+        # Use the Gemini 1.5 Pro model for improved reasoning capabilities
+        gemini_model_name = 'models/gemini-1.5-pro'
         gemini_llm = genai.GenerativeModel(gemini_model_name)
         print(f"Gemini API configured successfully with model: {gemini_model_name}")
 except Exception as e:


### PR DESCRIPTION
## Summary
- Switch text-generation backend to Gemini 1.5 Pro for enhanced reasoning.

## Testing
- `python -m py_compile app.py check.py`
- `python check.py` *(fails: KeyError: 'GEMINI_API_KEY')*

------
https://chatgpt.com/codex/tasks/task_e_68bf65d558b483319bc559dee97df11e